### PR TITLE
Add originating request IP

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "serve": "grunt serve"
   },
   "dependencies": {
+    "addr": "^1.0.1",
     "body-parser": "^1.15.2",
     "bootstrap": "^3.3.7",
     "connect-busboy": "0.0.2",

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -14,6 +14,7 @@ titleCase = require 'title-case'
 busboy = require 'connect-busboy'
 streamToArray = require 'stream-to-array'
 Sequelize = require 'sequelize'
+addr = require 'addr'
 
 crashreportToApiJson = (crashreport) ->
   json = crashreport.toJSON()
@@ -123,6 +124,11 @@ run = ->
   breakpad.post '/crashreports', (req, res, next) ->
     props = {}
     streamOps = []
+    # Get originating request address, respecting reverse proxies (e.g.
+    #   X-Forwarded-For header)
+    # Fixed list of just localhost as trusted reverse-proxy, we can add
+    #   a config option if needed
+    props.ip = addr(req, ['127.0.0.1', '::ffff:127.0.0.1'])
 
     req.busboy.on 'file', (fieldname, file, filename, encoding, mimetype) ->
       streamOps.push streamToArray(file).then((parts) ->

--- a/src/model/crashreport.coffee
+++ b/src/model/crashreport.coffee
@@ -19,6 +19,7 @@ schema =
     primaryKey: yes
   product: Sequelize.STRING
   version: Sequelize.STRING
+  ip: Sequelize.STRING
   upload_file_minidump: Sequelize.BLOB
 
 


### PR DESCRIPTION
I need this, and this is probably generally useful.  It would also be pretty reasonable to say all uploaded dumps should *always* store the originating IP, regardless of whether the user adds a parameter for this to their config.