### PR TITLE
Add `extensions` map for downloaded files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ database:
   storage: '/home/myuser/.simple-breakpad-server/database.sqlite'
   logging: false
 customFields:
-  files: ['customfile']
+  files:
+    - 'customfile1'
+    - name: 'customfile2'
+      downloadAs: 'customfile2.jpg'
   params: ['customparam']
-  extensions:
-    upload_file_minidump: '.dmp'
-    customfile: '.txt'
 dataDir: '/home/myuser/.simple-breakpad-server'
 ```
 
@@ -119,9 +119,9 @@ Database options are passed directly to [Sequelize](http://docs.sequelizejs.com/
 
 ### Custom Fields
 
-Place a list of file parameters in the `files` array. These will be stored in the database as blobs and can contain binary data. Non-files should go into the `params` array. These will be stored in the database encoded as strings.
+Place a list of file parameters in the `files` array. These will be stored in the database as blobs and can contain binary data. Non-files should go into the `params` array. These will be stored in the database encoded as strings.  File parameters can either be a simple string, or an object specifying a required `name` (used for upload and download url) and an optional `downloadAs` which specifies what name will be used when downloading.
 
-Custom `files` can be downloaded from the `GET /crashreports/<id>/files/<file>` endpoint and custom `params` will be shown on the main page for the crash report.  File downloads can be further customized with the `extensions` map, specifying what extension the downloaded file should have.  This can be especially useful with the `upload_file_minidump` field to set it to `.dmp` so that downloaded minidumps will open in Visual Studio or another appropriate debugger.
+Custom `files` can be downloaded from the `GET /crashreports/<id>/files/<file>` endpoint and custom `params` will be shown on the main page for the crash report.
 
 For now, if you change this configuration after the database is initialized, you will have to create the tables on your database manually for things to work.
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ database:
   logging: false
 customFields:
   files:
-    - 'customfile1'
+    - name: 'customfile1'
+      downloadAs: 'customfile1.jpg'
     - name: 'customfile2'
-      downloadAs: 'customfile2.jpg'
   params: ['customparam']
 dataDir: '/home/myuser/.simple-breakpad-server'
 ```

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ database:
 customFields:
   files: ['customfile']
   params: ['customparam']
+  extensions:
+    upload_file_minidump: '.dmp'
+    customfile: '.txt'
 dataDir: '/home/myuser/.simple-breakpad-server'
 ```
 
@@ -116,9 +119,9 @@ Database options are passed directly to [Sequelize](http://docs.sequelizejs.com/
 
 ### Custom Fields
 
-The `customFields` member has two members. Place a list of file parameters in the `files` array. These will be stored in the database as blobs and can contain binary data. Non-files should go into the `params` array. These will be stored in the database encoded as strings.
+Place a list of file parameters in the `files` array. These will be stored in the database as blobs and can contain binary data. Non-files should go into the `params` array. These will be stored in the database encoded as strings.
 
-Custom `files` can be downloaded from the `GET /crashreports/<id>/files/<file>` endpoint and custom `params` will be shown on the main page for the crash report.
+Custom `files` can be downloaded from the `GET /crashreports/<id>/files/<file>` endpoint and custom `params` will be shown on the main page for the crash report.  File downloads can be further customized with the `extensions` map, specifying what extension the downloaded file should have.  This can be especially useful with the `upload_file_minidump` field to set it to `.dmp` so that downloaded minidumps will open in Visual Studio or another appropriate debugger.
 
 For now, if you change this configuration after the database is initialized, you will have to create the tables on your database manually for things to work.
 

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -295,7 +295,7 @@ run = ->
       filename = config.get("customFields:filesById:#{field}:downloadAs") || field
       filename = filename.replace('#{id}', req.params.id)
 
-      res.setHeader('content-disposition', "attachment; filename=\"#{filename}\"");
+      res.setHeader('content-disposition', "attachment; filename=\"#{filename}\"")
       res.send(contents)
 
   breakpad.use(busboy())

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -291,11 +291,9 @@ run = ->
       if not Buffer.isBuffer(contents)
         return res.status(404).send 'Crash report field is not a file'
 
-      customFields = config.get('customFields') || {}
-      extensions = customFields.extensions || {}
-      filename = "#{field}.#{req.params.id}"
-      if extensions[field]
-        filename += extensions[field]
+      # Find appropriate downloadAs file name
+      filename = config.get("customFields:filesById:#{field}:downloadAs") || field
+      filename = filename.replace('#{id}', req.params.id)
 
       res.setHeader('content-disposition', "attachment; filename=\"#{filename}\"");
       res.send(contents)

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -293,7 +293,7 @@ run = ->
 
       # Find appropriate downloadAs file name
       filename = config.get("customFields:filesById:#{field}:downloadAs") || field
-      filename = filename.replace('#{id}', req.params.id)
+      filename = filename.replace('{{id}}', req.params.id)
 
       res.setHeader('content-disposition', "attachment; filename=\"#{filename}\"")
       res.send(contents)

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -285,11 +285,19 @@ run = ->
       if not crashreport?
         return res.status(404).send 'Crash report not found'
 
-      contents = crashreport.get(req.params.filefield)
+      field = req.params.filefield
+      contents = crashreport.get(field)
 
       if not Buffer.isBuffer(contents)
         return res.status(404).send 'Crash report field is not a file'
 
+      customFields = config.get('customFields') || {}
+      extensions = customFields.extensions || {}
+      filename = "#{field}.#{req.params.id}"
+      if extensions[field]
+        filename += extensions[field]
+
+      res.setHeader('content-disposition', "attachment; filename=\"#{filename}\"");
       res.send(contents)
 
   breakpad.use(busboy())

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -44,7 +44,7 @@ customFields.files = customFields.files || []
 # Always add upload_file_minidump file as first file
 customFields.files.splice(0, 0,
   name: 'upload_file_minidump'
-  downloadAs: 'upload_file_minidump.#{id}.dmp'
+  downloadAs: 'upload_file_minidump.{{id}}.dmp'
 )
 # Ensure array members are objects and build lookup
 customFields.filesById = {}

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -36,6 +36,40 @@ nconf.defaults
     params: []
   dataDir: SBS_HOME
 
+# Post-process custom files and params
+customFields = nconf.get('customFields')
+
+# Ensure array
+customFields.files = customFields.files || []
+# Always add upload_file_minidump file as first file
+customFields.files.splice(0, 0,
+  name: 'upload_file_minidump'
+  downloadAs: 'upload_file_minidump.#{id}.dmp'
+)
+# Ensure array members are objects and build lookup
+customFields.filesById = {}
+for field, idx in customFields.files
+  if typeof field is 'string'
+    customFields.files[idx] =
+      name: field
+  customFields.filesById[customFields.files[idx].name] = customFields.files[idx]
+
+# Ensure array
+customFields.params = customFields.params || []
+# Always add ip as first params
+customFields.params.splice(0, 0,
+  name: 'ip'
+)
+# Ensure array members are objects and build lookup
+customFields.paramsById = {}
+for field, idx in customFields.params
+  if typeof field is 'string'
+    customFields.params[idx] =
+      name: field
+  customFields.paramsById[customFields.params[idx].name] = customFields.params[idx]
+
+nconf.set('customFields', customFields)
+
 nconf.getSymbolsPath = -> path.join(nconf.get('dataDir'), 'symbols')
 
 fs.mkdirsSync(nconf.getSymbolsPath())

--- a/src/model/crashreport.coffee
+++ b/src/model/crashreport.coffee
@@ -19,20 +19,17 @@ schema =
     primaryKey: yes
   product: Sequelize.STRING
   version: Sequelize.STRING
-  ip: Sequelize.STRING
-  upload_file_minidump: Sequelize.BLOB
-
 
 options =
   indexes: [
     { fields: ['created_at'] }
   ]
 
-for field in (customFields.params || [])
-  schema[field] = Sequelize.STRING
+for field in customFields.params
+  schema[field.name] = Sequelize.STRING
 
-for field in (customFields.files || [])
-  schema[field] = Sequelize.BLOB
+for field in customFields.files
+  schema[field.name] = Sequelize.BLOB
 
 Crashreport = sequelize.define('crashreports', schema, options)
 


### PR DESCRIPTION
Allows specifying the downloaded file's extension when the browser saves a file to disk.  Especially useful for dump files.