### PR TITLE
Fix out of memory errors by adding "filesInDatabase" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ customFields:
     - name: 'customfile2'
   params: ['customparam']
 dataDir: '/home/myuser/.simple-breakpad-server'
+fileMaxUploadSize: 100000000
+filesInDatabase: true
 ```
 
 ### Database configuration
@@ -128,6 +130,12 @@ For now, if you change this configuration after the database is initialized, you
 ### Data Directory
 
 Simple breakpad server caches symbols on the disk within the directory specified by `dataDir`. The default location is `$HOME/.simple-breakpad-server`.
+
+## Uploaded Files
+
+By default, there is no enforced limit to uploaded file size (limited by Node.js heap size and database size), and uploaded files (minidumps or custom files) are stored directly in the database.  The maximum allowed file size can be specified with `fileMaxUploadSize` (in bytes).
+
+The server can be directed to store all uploaded files on disk (instead of in the database) with `filesInDatabase: false`, however the dumps may be unable to be read after switching, so the database should be recreated (manually delete the `database.sqlite` file from your data directory).  Old symbols files (already on disk) should still work fine after changing this setting, even if they don't show up in the web interface's Symfiles list.  Note: if `filesInDatabase` is set to `false`, and you are doing backups, you should back up your entire data directory (or, at least, the symbols/ directory) in addition to your database file.
 
 ## Contributing
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -35,6 +35,8 @@ nconf.defaults
     files: []
     params: []
   dataDir: SBS_HOME
+  filesInDatabase: true
+  fileMaxUploadSize: Infinity
 
 # Post-process custom files and params
 customFields = nconf.get('customFields')
@@ -71,6 +73,7 @@ for field, idx in customFields.params
 nconf.set('customFields', customFields)
 
 nconf.getSymbolsPath = -> path.join(nconf.get('dataDir'), 'symbols')
+nconf.getUploadPath = -> path.join(nconf.get('dataDir'), 'uploads')
 
 fs.mkdirsSync(nconf.getSymbolsPath())
 

--- a/src/model/crashreport.coffee
+++ b/src/model/crashreport.coffee
@@ -29,12 +29,29 @@ for field in customFields.params
   schema[field.name] = Sequelize.STRING
 
 for field in customFields.files
-  schema[field.name] = Sequelize.BLOB
+  schema[field.name] = if config.get('filesInDatabase') then Sequelize.BLOB else Sequelize.STRING
 
 Crashreport = sequelize.define('crashreports', schema, options)
 
 Crashreport.getStackTrace = (record, callback) ->
   return callback(null, cache.get(record.id)) if cache.has record.id
+
+  if !config.get('filesInDatabase')
+    # If this is a string, or a string stored as a blob in an old database,
+    # just use the on-disk file instead
+    onDiskFilename = record.upload_file_minidump
+    if Buffer.isBuffer(record.upload_file_minidump)
+      if record.upload_file_minidump.length > 128
+        # Large, must be an old actual dump stored in the database
+        onDiskFilename = null
+      else
+        onDiskFilename = record.upload_file_minidump.toString('utf8')
+    if onDiskFilename
+      # use existing file, do not delete when done!
+      use_filename = path.join(config.getUploadPath(), onDiskFilename)
+      return minidump.walkStack use_filename, [symbolsPath], (err, report) ->
+        cache.set record.id, report unless err?
+        callback err, report
 
   tmpfile = tmp.fileSync()
   fs.writeFile(tmpfile.name, record.upload_file_minidump).then ->


### PR DESCRIPTION
I ran into some out of memory errors on my (albeit small) instance when the uploaded dumps got to a couple GB, and more recently when the uploaded symbols got to a couple GB, so I added an option to store all uploaded files on disk instead of in the database.  This reduced my runtime memory usage of the breakpad server from a few GB down to a few MB, solving my issues.