### PR TITLE
Bump NPM version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-breakpad-server",
   "description": "Simple breakpad crash reports collecting server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Tony Crisci (https://github.com/acrisci)",
   "contributors": [
     "Jimb Esser (https://github.com/Jimbly)"


### PR DESCRIPTION
@acrisci I'd like to publish the latest fixes to NPM as v1.1.0, but I do not have access.  If that's acceptable, when you have a chance, please go to https://www.npmjs.com/package/simple-breakpad-server/access and grant `jimbly` access and I should be able to publish it myself going forward.